### PR TITLE
Add missing ')'

### DIFF
--- a/ossperf.sh
+++ b/ossperf.sh
@@ -389,7 +389,7 @@ fi
 # This is not a part of the benchmark!
 for ((i=1; i<=${NUM_FILES}; i+=1))
 do
-  if dd if=/dev/urandom of=$DIRECTORY/ossperf-testfile$i.txt bs=4096 count=$(($SIZE_FILES/4096) ; then
+  if dd if=/dev/urandom of=$DIRECTORY/ossperf-testfile$i.txt bs=4096 count=$(($SIZE_FILES/4096)) ; then
     echo -e "${GREEN}[OK] File with random content has been created.${NC}"
   else
     echo -e "${RED}[ERROR] Unable to create the file.${NC}" && exit 1


### PR DESCRIPTION
```
OK] The storage service can be accessed via the tool s3cmd.
[OK] The directory testfiles has been created in the local directory.
./ossperf.sh: line 392: unexpected EOF while looking for matching `)'
./ossperf.sh: line 1173: syntax error: unexpected end of file
```