### PR TITLE
Fix typo in ENDPOINT_URL_ADDRESS variable

### DIFF
--- a/ossperf.sh
+++ b/ossperf.sh
@@ -993,7 +993,7 @@ else
     # If the variable $ENDPOINT_URL_ADDRESS is not empty...
     else
       # use the s4cmd cli with an S3-compatible non-Amazon service (e.g. Minio)
-      if s4cmd --endpoint-url="$ENDPOINT_URL_ADDRESS" put $DIRECTORY/*.txt s3://$BUCKET/ -s -f ; then
+      if s4cmd --endpoint-url="$ENDPOINT_URL_ADDRESS" put $DIRECTORY/*.txt s3://$BUCKET/ ; then
         echo -e "${GREEN}[OK] Files have been uploaded sequentially with s4cmd.${NC}"
       else
         echo -e "${RED}[ERROR] Unable to upload the files sequentially with s4cmd.${NC}" && exit 1

--- a/ossperf.sh
+++ b/ossperf.sh
@@ -993,7 +993,7 @@ else
     # If the variable $ENDPOINT_URL_ADDRESS is not empty...
     else
       # use the s4cmd cli with an S3-compatible non-Amazon service (e.g. Minio)
-      if s4cmd --endpoint-url="$ENDPOINT_URL_ADDRES" put $DIRECTORY/*.txt s3://$BUCKET ; then
+      if s4cmd --endpoint-url="$ENDPOINT_URL_ADDRESS" put $DIRECTORY/*.txt s3://$BUCKET/ -s -f ; then
         echo -e "${GREEN}[OK] Files have been uploaded sequentially with s4cmd.${NC}"
       else
         echo -e "${RED}[ERROR] Unable to upload the files sequentially with s4cmd.${NC}" && exit 1


### PR DESCRIPTION
I have utilized the script on Windows, and I wasn't able to get s3cmd to work, but s4cmd worked nicely. I had to modify several places in the script to make it work. I don't believe the script is assumed to be used on windows and I am not good at bash, so I won't propose all fixes, but this PR contains a universal fix.
In addition to the typo fix s4cmd seems to require a slash in the URL as I got from https://github.com/bloomreach/s4cmd/issues/93#issuecomment-569392840